### PR TITLE
Fix error when building with gcc 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(wfind)
+set(CMAKE_CXX_STANDARD 17)
 
 add_library(wfind_lib STATIC lib/wfind.cpp)
 


### PR DESCRIPTION
For some reason, Clang failed to detect features when compile with GCC 9 (and perhaps Clang 8). To match the specification, CMakeLists.txt is now enforced `CMAKE_CXX_STANDARD` to be `17`